### PR TITLE
Use new datatypes where possible

### DIFF
--- a/bundles/org.palladiosimulator.spd/model/SPD.ecore
+++ b/bundles/org.palladiosimulator.spd/model/SPD.ecore
@@ -118,7 +118,7 @@
         <details key="documentation" value="The AbsoluteAdjustment denotes that the group is adjusted to a goal value."/>
       </eAnnotations>
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="goalValue" lowerBound="1"
-          eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt" defaultValueLiteral="0">
+          eType="#//datatypes/PositiveInteger" defaultValueLiteral="0">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="The goalValue determines the target number of elements for a particular group, e.g., a value 5 means that the group will have 5 elements."/>
         </eAnnotations>
@@ -390,13 +390,13 @@
       </eClassifiers>
       <eClassifiers xsi:type="ecore:EClass" name="NoExpectation" eSuperTypes="#//triggers/expectations/ExpectedValue"/>
       <eClassifiers xsi:type="ecore:EClass" name="ExpectedPercentage" eSuperTypes="#//triggers/expectations/ExpectedPrimitive">
-        <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EDouble"/>
+        <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//datatypes/WholePercentDouble"/>
       </eClassifiers>
       <eClassifiers xsi:type="ecore:EClass" name="ExpectedCount" eSuperTypes="#//triggers/expectations/ExpectedPrimitive">
-        <eStructuralFeatures xsi:type="ecore:EAttribute" name="count" eType="ecore:EDataType platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EInt"/>
+        <eStructuralFeatures xsi:type="ecore:EAttribute" name="count" eType="#//datatypes/PositiveInteger"/>
       </eClassifiers>
       <eClassifiers xsi:type="ecore:EClass" name="ExpectedTime" eSuperTypes="#//triggers/expectations/ExpectedPrimitive">
-        <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EDouble"/>
+        <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="#//datatypes/PositiveDouble"/>
       </eClassifiers>
       <eClassifiers xsi:type="ecore:EClass" name="ExpectedTrend" eSuperTypes="#//triggers/expectations/ExpectedValue">
         <eStructuralFeatures xsi:type="ecore:EAttribute" name="trend" eType="#//triggers/TrendPattern"/>
@@ -500,6 +500,12 @@
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EDataType" name="PositiveDouble" instanceClassName="double">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="minInclusive" value="0.0"/>
+      </eAnnotations>
+    </eClassifiers>
+    <eClassifiers xsi:type="ecore:EDataType" name="WholePercentDouble" instanceClassName="double">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="maxInclusive" value="100.0"/>
         <details key="minInclusive" value="0.0"/>
       </eAnnotations>
     </eClassifiers>

--- a/bundles/org.palladiosimulator.spd/model/SPD.genmodel
+++ b/bundles/org.palladiosimulator.spd/model/SPD.genmodel
@@ -232,6 +232,7 @@
       <genDataTypes ecoreDataType="SPD.ecore#//datatypes/PercentDouble"/>
       <genDataTypes ecoreDataType="SPD.ecore#//datatypes/PositiveInteger"/>
       <genDataTypes ecoreDataType="SPD.ecore#//datatypes/PositiveDouble"/>
+      <genDataTypes ecoreDataType="SPD.ecore#//datatypes/WholePercentDouble"/>
     </nestedGenPackages>
   </genPackages>
 </genmodel:GenModel>

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/adjustments/impl/AdjustmentsPackageImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/adjustments/impl/AdjustmentsPackageImpl.java
@@ -362,6 +362,10 @@ public class AdjustmentsPackageImpl extends EPackageImpl implements AdjustmentsP
         this.setNsPrefix(eNS_PREFIX);
         this.setNsURI(eNS_URI);
 
+        // Obtain other dependent packages
+        final DatatypesPackage theDatatypesPackage = (DatatypesPackage) EPackage.Registry.INSTANCE
+            .getEPackage(DatatypesPackage.eNS_URI);
+
         // Create type parameters
 
         // Set bounds for type parameters
@@ -389,9 +393,9 @@ public class AdjustmentsPackageImpl extends EPackageImpl implements AdjustmentsP
 
         this.initEClass(this.absoluteAdjustmentEClass, AbsoluteAdjustment.class, "AbsoluteAdjustment", !IS_ABSTRACT,
                 !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        this.initEAttribute(this.getAbsoluteAdjustment_GoalValue(), this.ecorePackage.getEInt(), "goalValue", "0", 1, 1,
-                AbsoluteAdjustment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-                !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getAbsoluteAdjustment_GoalValue(), theDatatypesPackage.getPositiveInteger(),
+                "goalValue", "0", 1, 1, AbsoluteAdjustment.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
+                !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.stepAdjustmentEClass, StepAdjustment.class, "StepAdjustment", !IS_ABSTRACT, !IS_INTERFACE,
                 IS_GENERATED_INSTANCE_CLASS);

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/DatatypesPackage.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/DatatypesPackage.java
@@ -78,6 +78,15 @@ public interface DatatypesPackage extends EPackage {
     int POSITIVE_DOUBLE = 2;
 
     /**
+     * The meta object id for the '<em>Whole Percent Double</em>' data type. <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
+     * @see org.palladiosimulator.spd.datatypes.impl.DatatypesPackageImpl#getWholePercentDouble()
+     * @generated
+     */
+    int WHOLE_PERCENT_DOUBLE = 3;
+
+    /**
      * Returns the meta object for data type '<em>Percent Double</em>'. <!-- begin-user-doc --> <!--
      * end-user-doc -->
      *
@@ -106,6 +115,16 @@ public interface DatatypesPackage extends EPackage {
      * @generated
      */
     EDataType getPositiveDouble();
+
+    /**
+     * Returns the meta object for data type '<em>Whole Percent Double</em>'. <!-- begin-user-doc
+     * --> <!-- end-user-doc -->
+     *
+     * @return the meta object for data type '<em>Whole Percent Double</em>'.
+     * @model instanceClass="double" extendedMetaData="maxInclusive='100.0' minInclusive='0.0'"
+     * @generated
+     */
+    EDataType getWholePercentDouble();
 
     /**
      * Returns the factory that creates the instances of the model. <!-- begin-user-doc --> <!--
@@ -155,6 +174,15 @@ public interface DatatypesPackage extends EPackage {
          * @generated
          */
         EDataType POSITIVE_DOUBLE = eINSTANCE.getPositiveDouble();
+
+        /**
+         * The meta object literal for the '<em>Whole Percent Double</em>' data type. <!--
+         * begin-user-doc --> <!-- end-user-doc -->
+         *
+         * @see org.palladiosimulator.spd.datatypes.impl.DatatypesPackageImpl#getWholePercentDouble()
+         * @generated
+         */
+        EDataType WHOLE_PERCENT_DOUBLE = eINSTANCE.getWholePercentDouble();
 
     }
 

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/impl/DatatypesFactoryImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/impl/DatatypesFactoryImpl.java
@@ -72,6 +72,8 @@ public class DatatypesFactoryImpl extends EFactoryImpl implements DatatypesFacto
             return this.createPositiveIntegerFromString(eDataType, initialValue);
         case DatatypesPackage.POSITIVE_DOUBLE:
             return this.createPositiveDoubleFromString(eDataType, initialValue);
+        case DatatypesPackage.WHOLE_PERCENT_DOUBLE:
+            return this.createWholePercentDoubleFromString(eDataType, initialValue);
         default:
             throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
         }
@@ -91,6 +93,8 @@ public class DatatypesFactoryImpl extends EFactoryImpl implements DatatypesFacto
             return this.convertPositiveIntegerToString(eDataType, instanceValue);
         case DatatypesPackage.POSITIVE_DOUBLE:
             return this.convertPositiveDoubleToString(eDataType, instanceValue);
+        case DatatypesPackage.WHOLE_PERCENT_DOUBLE:
+            return this.convertWholePercentDoubleToString(eDataType, instanceValue);
         default:
             throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
         }
@@ -147,6 +151,24 @@ public class DatatypesFactoryImpl extends EFactoryImpl implements DatatypesFacto
      * @generated
      */
     public String convertPositiveDoubleToString(final EDataType eDataType, final Object instanceValue) {
+        return super.convertToString(eDataType, instanceValue);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    public Double createWholePercentDoubleFromString(final EDataType eDataType, final String initialValue) {
+        return (Double) super.createFromString(eDataType, initialValue);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    public String convertWholePercentDoubleToString(final EDataType eDataType, final Object instanceValue) {
         return super.convertToString(eDataType, instanceValue);
     }
 

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/impl/DatatypesPackageImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/impl/DatatypesPackageImpl.java
@@ -66,6 +66,13 @@ public class DatatypesPackageImpl extends EPackageImpl implements DatatypesPacka
     private EDataType positiveDoubleEDataType = null;
 
     /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    private EDataType wholePercentDoubleEDataType = null;
+
+    /**
      * Creates an instance of the model <b>Package</b>, registered with
      * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package package URI
      * value.
@@ -245,6 +252,16 @@ public class DatatypesPackageImpl extends EPackageImpl implements DatatypesPacka
      * @generated
      */
     @Override
+    public EDataType getWholePercentDouble() {
+        return this.wholePercentDoubleEDataType;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public DatatypesFactory getDatatypesFactory() {
         return (DatatypesFactory) this.getEFactoryInstance();
     }
@@ -272,6 +289,7 @@ public class DatatypesPackageImpl extends EPackageImpl implements DatatypesPacka
         this.percentDoubleEDataType = this.createEDataType(PERCENT_DOUBLE);
         this.positiveIntegerEDataType = this.createEDataType(POSITIVE_INTEGER);
         this.positiveDoubleEDataType = this.createEDataType(POSITIVE_DOUBLE);
+        this.wholePercentDoubleEDataType = this.createEDataType(WHOLE_PERCENT_DOUBLE);
     }
 
     /**
@@ -305,6 +323,8 @@ public class DatatypesPackageImpl extends EPackageImpl implements DatatypesPacka
                 !IS_GENERATED_INSTANCE_CLASS);
         this.initEDataType(this.positiveDoubleEDataType, double.class, "PositiveDouble", IS_SERIALIZABLE,
                 !IS_GENERATED_INSTANCE_CLASS);
+        this.initEDataType(this.wholePercentDoubleEDataType, double.class, "WholePercentDouble", IS_SERIALIZABLE,
+                !IS_GENERATED_INSTANCE_CLASS);
 
         // Create annotations
         // http:///org/eclipse/emf/ecore/util/ExtendedMetaData
@@ -323,6 +343,8 @@ public class DatatypesPackageImpl extends EPackageImpl implements DatatypesPacka
                 new String[] { "maxInclusive", "1.0", "minInclusive", "0.0" });
         this.addAnnotation(this.positiveIntegerEDataType, source, new String[] { "minInclusive", "0" });
         this.addAnnotation(this.positiveDoubleEDataType, source, new String[] { "minInclusive", "0.0" });
+        this.addAnnotation(this.wholePercentDoubleEDataType, source,
+                new String[] { "maxInclusive", "100.0", "minInclusive", "0.0" });
     }
 
 } // DatatypesPackageImpl

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/util/DatatypesValidator.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/datatypes/util/DatatypesValidator.java
@@ -87,6 +87,8 @@ public class DatatypesValidator extends EObjectValidator {
             return this.validatePositiveInteger((Integer) value, diagnostics, context);
         case DatatypesPackage.POSITIVE_DOUBLE:
             return this.validatePositiveDouble((Double) value, diagnostics, context);
+        case DatatypesPackage.WHOLE_PERCENT_DOUBLE:
+            return this.validateWholePercentDouble((Double) value, diagnostics, context);
         default:
             return true;
         }
@@ -220,6 +222,68 @@ public class DatatypesValidator extends EObjectValidator {
         if (!result && diagnostics != null) {
             this.reportMinViolation(DatatypesPackage.Literals.POSITIVE_DOUBLE, positiveDouble,
                     POSITIVE_DOUBLE__MIN__VALUE, true, diagnostics, context);
+        }
+        return result;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    public boolean validateWholePercentDouble(final double wholePercentDouble, final DiagnosticChain diagnostics,
+            final Map<Object, Object> context) {
+        boolean result = this.validateWholePercentDouble_Min(wholePercentDouble, diagnostics, context);
+        if (result || diagnostics != null) {
+            result &= this.validateWholePercentDouble_Max(wholePercentDouble, diagnostics, context);
+        }
+        return result;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @see #validateWholePercentDouble_Min
+     */
+    public static final double WHOLE_PERCENT_DOUBLE__MIN__VALUE = 0.0;
+
+    /**
+     * Validates the Min constraint of '<em>Whole Percent Double</em>'. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     */
+    public boolean validateWholePercentDouble_Min(final double wholePercentDouble, final DiagnosticChain diagnostics,
+            final Map<Object, Object> context) {
+        final boolean result = wholePercentDouble >= WHOLE_PERCENT_DOUBLE__MIN__VALUE;
+        if (!result && diagnostics != null) {
+            this.reportMinViolation(DatatypesPackage.Literals.WHOLE_PERCENT_DOUBLE, wholePercentDouble,
+                    WHOLE_PERCENT_DOUBLE__MIN__VALUE, true, diagnostics, context);
+        }
+        return result;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @see #validateWholePercentDouble_Max
+     */
+    public static final double WHOLE_PERCENT_DOUBLE__MAX__VALUE = 100.0;
+
+    /**
+     * Validates the Max constraint of '<em>Whole Percent Double</em>'. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     */
+    public boolean validateWholePercentDouble_Max(final double wholePercentDouble, final DiagnosticChain diagnostics,
+            final Map<Object, Object> context) {
+        final boolean result = wholePercentDouble <= WHOLE_PERCENT_DOUBLE__MAX__VALUE;
+        if (!result && diagnostics != null) {
+            this.reportMaxViolation(DatatypesPackage.Literals.WHOLE_PERCENT_DOUBLE, wholePercentDouble,
+                    WHOLE_PERCENT_DOUBLE__MAX__VALUE, true, diagnostics, context);
         }
         return result;
     }

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/ExpectedCount.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/ExpectedCount.java
@@ -27,7 +27,7 @@ public interface ExpectedCount extends ExpectedPrimitive {
      * @return the value of the '<em>Count</em>' attribute.
      * @see #setCount(int)
      * @see org.palladiosimulator.spd.triggers.expectations.ExpectationsPackage#getExpectedCount_Count()
-     * @model
+     * @model dataType="org.palladiosimulator.spd.datatypes.PositiveInteger"
      * @generated
      */
     int getCount();

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/ExpectedPercentage.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/ExpectedPercentage.java
@@ -27,7 +27,7 @@ public interface ExpectedPercentage extends ExpectedPrimitive {
      * @return the value of the '<em>Value</em>' attribute.
      * @see #setValue(double)
      * @see org.palladiosimulator.spd.triggers.expectations.ExpectationsPackage#getExpectedPercentage_Value()
-     * @model
+     * @model dataType="org.palladiosimulator.spd.datatypes.WholePercentDouble"
      * @generated
      */
     double getValue();

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/ExpectedTime.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/ExpectedTime.java
@@ -27,7 +27,7 @@ public interface ExpectedTime extends ExpectedPrimitive {
      * @return the value of the '<em>Value</em>' attribute.
      * @see #setValue(double)
      * @see org.palladiosimulator.spd.triggers.expectations.ExpectationsPackage#getExpectedTime_Value()
-     * @model
+     * @model dataType="org.palladiosimulator.spd.datatypes.PositiveDouble"
      * @generated
      */
     double getValue();

--- a/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/impl/ExpectationsPackageImpl.java
+++ b/bundles/org.palladiosimulator.spd/src/org/palladiosimulator/spd/triggers/expectations/impl/ExpectationsPackageImpl.java
@@ -423,8 +423,8 @@ public class ExpectationsPackageImpl extends EPackageImpl implements Expectation
         this.setNsURI(eNS_URI);
 
         // Obtain other dependent packages
-        final EcorePackage theEcorePackage = (EcorePackage) EPackage.Registry.INSTANCE
-            .getEPackage(EcorePackage.eNS_URI);
+        final DatatypesPackage theDatatypesPackage = (DatatypesPackage) EPackage.Registry.INSTANCE
+            .getEPackage(DatatypesPackage.eNS_URI);
         final TriggersPackage theTriggersPackage = (TriggersPackage) EPackage.Registry.INSTANCE
             .getEPackage(TriggersPackage.eNS_URI);
 
@@ -458,19 +458,19 @@ public class ExpectationsPackageImpl extends EPackageImpl implements Expectation
 
         this.initEClass(this.expectedPercentageEClass, ExpectedPercentage.class, "ExpectedPercentage", !IS_ABSTRACT,
                 !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        this.initEAttribute(this.getExpectedPercentage_Value(), theEcorePackage.getEDouble(), "value", null, 0, 1,
-                ExpectedPercentage.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-                !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getExpectedPercentage_Value(), theDatatypesPackage.getWholePercentDouble(), "value",
+                null, 0, 1, ExpectedPercentage.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE,
+                !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.expectedCountEClass, ExpectedCount.class, "ExpectedCount", !IS_ABSTRACT, !IS_INTERFACE,
                 IS_GENERATED_INSTANCE_CLASS);
-        this.initEAttribute(this.getExpectedCount_Count(), theEcorePackage.getEInt(), "count", null, 0, 1,
-                ExpectedCount.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
+        this.initEAttribute(this.getExpectedCount_Count(), theDatatypesPackage.getPositiveInteger(), "count", null, 0,
+                1, ExpectedCount.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
                 !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.expectedTimeEClass, ExpectedTime.class, "ExpectedTime", !IS_ABSTRACT, !IS_INTERFACE,
                 IS_GENERATED_INSTANCE_CLASS);
-        this.initEAttribute(this.getExpectedTime_Value(), theEcorePackage.getEDouble(), "value", null, 0, 1,
+        this.initEAttribute(this.getExpectedTime_Value(), theDatatypesPackage.getPositiveDouble(), "value", null, 0, 1,
                 ExpectedTime.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
                 !IS_DERIVED, IS_ORDERED);
 


### PR DESCRIPTION
Adapt the Expectations and the Adjustments to use the newly introduced custom datatypes where possible.
For the `ExpectedPercentage`, a new datatype `WholePercentDouble` is introduced: It specifies the percentage as a value between 0.0 and 100.0, unlike the `PercentDouble` datatype which has a range between 0.0 and 1.0. 

One thing to note: Modifying either the `ExpectedPercentage` to also use `PercentDouble` and thus a range between 0 and 1 or alternatively the `probability` attribute of `RandomModel` to use `WholePercentDouble` and thus a range between 0 and 100 would be desirable to get more consistency (this would however need a small implementation adjustment).
The `PercentDouble` datatype is also used for the `epsilon` and `discountFactor` attributes of `FuzzyLearningModel` where a range from 0 to 100 wouldn't make sense, so the `PercentDouble` datatype could not be removed even when using `WholePercentDouble` for the `probability` attribute, so always using the `PercentDouble` datatype and expressing percentages as values between 0 and 1 in the model would lead to a smaller model that needs one less datatype. However, this would of course be a breaking change for existing models.