### PR TITLE
Migrate to parent pom version 0.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.8.9</version>
+		<version>0.9.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.spd</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/org.palladiosimulator.spd.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.spd.targetplatform/tp.target
@@ -7,6 +7,8 @@
 		<unit id="de.uka.ipd.sdq.dsexplore.feature.feature.group" version="0.0.0"/>
 		<unit id="de.uka.ipd.sdq.featuremodel.feature.featureinstanceeditor.feature.group" version="0.0.0"/>
 		<unit id="de.uka.ipd.sdq.featuremodel.feature.model.feature.group" version="0.0.0"/>
+		<unit id="org.palladiosimulator.monitorrepository.feature.feature.group" version="0.0.0"/>
+		<unit id="org.palladiosimulator.servicelevelobjective.feature.feature.group" version="0.0.0"/>
 		<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
 	</location>
 	</locations>


### PR DESCRIPTION
- Migrate from parent POM version 0.8.9 to the new parent POM version 0.9.0
- Add missing dependencies to tp.target
- Locally verified build success